### PR TITLE
Check for existence of gdm and mdm config

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -205,6 +205,9 @@ class InstallerEngine:
             our_current += 1
             self.update_progress(total=our_total, current=our_current, message=_("Removing live configuration (packages)"))
             self.do_run_in_chroot("apt-get remove --purge --yes --force-yes live-boot live-boot-initramfs-tools live-initramfs live-installer live-config live-config-sysvinit")
+            # On KDE the purge is incomplete and leaves redundant symbolic links in the rc*.d directories.
+            # The resulting startpar error prevents gsfxi to successfully install the Nvidia drivers.
+            self.do_run_in_chroot("update-rc.d -f live-installer remove")
             
             # add new user
             print " --> Adding new user"


### PR DESCRIPTION
On KDE the live-installer hangs when trying to open the GDM or MDM configuration file.
Checking for both these files for existence does prevent the hang on a KDM system.
