### PR TITLE
Enable the Forward button after the user closes the dialog during a custom install

### DIFF
--- a/usr/lib/live-installer/frontend/gtk_interface.py
+++ b/usr/lib/live-installer/frontend/gtk_interface.py
@@ -1765,6 +1765,7 @@ class InstallerWindow:
                     self.wTree.get_widget("button_next").show()
                     MessageDialog(_("Installation Paused"), _("Installation is now paused. Please read the instructions on the page carefully and click Forward to finish installation."), gtk.MESSAGE_INFO, self.window).show()
                     gtk.gdk.threads_leave()
+                    self.wTree.get_widget("button_next").set_sensitive(True)
 
                     while(self.paused):
                         time.sleep(0.1)


### PR DESCRIPTION
Howdy! 

There's a bug in the installer when choosing a custom install (the one where you can specify different partitions and you have to create your own fstab). At a point near the end of the installation process, a dialog box pops up telling the user to follow the instructions on the main window. After the user closes the dialog box (and does whatever they need to do) the Forward ("button_next") remains disabled which prevents them from completing the installation process. 

I added this extra line in when I was doing an install and it let me continue - so it is kind of tested :-P 

I have no idea if it is the best way to fix the issue. I haven't seen GTK code before, it just looked like a logical spot for it.
