### PR TITLE
Use rsync for transferring files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Depends: ${misc:Depends}, ${python:Depends}
   , gdisk
   , isoquery, iso-codes, locales
   , adduser
+  , rsync
 Description: Live Installer
  A live installer
 


### PR DESCRIPTION
This seems like a nicer way to do it. rsync is told to copy everything except pipes, sockets (used for IPC; everything needed will be constructed on next boot anyway), and devices (save for hackers playing around, those are confined to /dev anyway). [Some directories](https://github.com/linuxmint/live-installer/pull/53/files#diff-6d2ebff65a6be23cb76ac7722e7dc460R150) are justifiably omitted, everything is transfered as-is, more reliably and in half the time.

~~This is yet untested as I'm waiting for my live jessie to come out of the "kitchen" (live-systems custom build service). It's been almost two days now.~~
