### PR TITLE
Replaced useradd with adduser, added more default groups

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,6 +31,7 @@ Depends: ${misc:Depends}, ${python:Depends}
   , gdisk
   , isoquery, iso-codes, locales
   , python-configobj
+  , adduser
 Description: Live Installer
  A live installer
 

--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -263,9 +263,9 @@ class InstallerEngine:
         print " --> Adding new user"
         our_current += 1
         self.update_progress(total=our_total, current=our_current, message=_("Adding new user to the system"))
-        self.do_run_in_chroot("useradd -s %s -c \'%s\' -G sudo,adm,dialout,audio,video,cdrom,floppy,dip,plugdev,lpadmin,sambashare -m %s" % ("/bin/bash", setup.real_name, setup.username))
-        os.system("chroot /target/ /bin/bash -c \"shopt -s dotglob && cp -R /etc/skel/* /home/%s/\"" % setup.username)
-        self.do_run_in_chroot("chown -R %s:%s /home/%s" % (setup.username, setup.username, setup.username))
+        self.do_run_in_chroot('adduser --disabled-login --gecos "{real_name}" {username}'.format(real_name=setup.real_name.replace('"', r'\"'), username=setup.username))
+        for group in 'adm audio bluetooth cdrom dialout dip fax floppy fuse lpadmin netdev plugdev powerdev sambashare scanner sudo tape users vboxusers video'.split():
+            self.do_run_in_chroot("adduser {user} {group}".format(user=setup.username, group=group))
 
         fp = open("/target/tmp/.passwd", "w")
         fp.write(setup.username +  ":" + setup.password1 + "\n")


### PR DESCRIPTION
Non-existant groups just fail (as opposed to `useradd -G`, where the whole command fails if any of the groups doesn't exist).