### PR TITLE
Drop configobj dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,6 @@ Depends: ${misc:Depends}, ${python:Depends}
   , menu
   , gdisk
   , isoquery, iso-codes, locales
-  , python-configobj
 Description: Live Installer
  A live installer
 

--- a/etc/live-installer/live-installer.conf
+++ b/etc/live-installer/live-installer.conf
@@ -1,5 +1,4 @@
 # Installation-specific configuration
-[install]
 live_user = mint
 live_media_type = squashfs
 live_media_source = /lib/live/mount/medium/live/filesystem.squashfs


### PR DESCRIPTION
Since our need for config parsing is minimal, and if we drop the only section in our config file (and make the keys global), everything can be covered in a few lines of code, hence the configobj dependency is redundant. :)