### PR TITLE
Use geoip.ubuntu.com/lookup for country/timezone lookup

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,8 +18,6 @@ Depends: ${misc:Depends}, ${python:Depends}
   , python-webkit
   , python-parted
   , gparted
-  , python-geoip
-  , geoip-database-contrib
   , python-qt4
   , python-opencv
   , python-imaging


### PR DESCRIPTION
The merits of this commit have been discussed in [#39](https://github.com/linuxmint/live-installer/pull/39#issuecomment-53173325). There are no drawbacks except relying on Ubuntu who might disable this URL at any time ([not really](https://launchpad.net/+search?field.text=geoip.ubuntu.com%2Flookup)), but you can always put up an alternative webservice serving GeoIP clues instead of showing IP only.