### PR TITLE
More concise /etc/fstab generation

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -303,49 +303,28 @@ class InstallerEngine:
         print " --> Writing fstab"
         our_current += 1
         self.update_progress(total=our_total, current=our_current, message=_("Writing filesystem mount information to /etc/fstab"))
-        # make sure fstab has default /proc and /sys entries
-        if(not os.path.exists("/target/etc/fstab")):
-            os.system("echo \"#### Static Filesystem Table File\" > /target/etc/fstab")
-        fstab = open("/target/etc/fstab", "a")
-        fstab.write("proc\t/proc\tproc\tdefaults\t0\t0\n")
-        if(not setup.skip_mount):
-            for partition in setup.partitions:
-                if (partition.mount_as is not None and partition.mount_as != "None"):
-                    partition_uuid = partition.partition.path # If we can't find the UUID we use the path
-                    blkid = commands.getoutput('blkid').split('\n')
-                    for blkid_line in blkid:
-                        blkid_elements = blkid_line.split(':')
-                        if blkid_elements[0] == partition.partition.path:
-                            blkid_mini_elements = blkid_line.split()
-                            for blkid_mini_element in blkid_mini_elements:
-                                if "UUID=" in blkid_mini_element:
-                                    partition_uuid = blkid_mini_element.replace('"', '').strip()
-                                    break
-                            break
-
-                    fstab.write("# %s\n" % (partition.partition.path))
-
-                    if(partition.mount_as == "/"):
-                        fstab_fsck_option = "1"
-                    else:
-                        fstab_fsck_option = "0"
-
-                    if("ext" in partition.type):
-                        fstab_mount_options = "rw,errors=remount-ro"
-                    else:
-                        fstab_mount_options = "defaults"
-
-                    if partition.type == "fat16" or partition.type == "fat32":
-                        fs = "vfat"
-                    else:
-                        fs = partition.type
-
-                    if(fs == "swap"):
-                        fstab.write("%s\tswap\tswap\tsw\t0\t0\n" % partition_uuid)
-                    else:
-                        fstab.write("%s\t%s\t%s\t%s\t%s\t%s\n" % (partition_uuid, partition.mount_as, fs, fstab_mount_options, "0", fstab_fsck_option))
-        fstab.close()
-
+        if not os.path.exists("/target/etc/fstab"):
+            os.system("echo '#### Static Filesystem Table File' > /target/etc/fstab")
+        if not setup.skip_mount:
+            with open("/target/etc/fstab", "a") as fstab:
+                for part in setup.partitions:
+                    if not part.mount_as and part.mount_as == 'None':
+                        continue  # skip partitions unconfigured in the installer
+                    # get UUID if available, or device path otherwise
+                    uuid = commands.getoutput('blkid -s UUID -o export ' + part.partition.path) or part.partition.path
+                    # fsck rootfs first (1), everything else second (2), except ntfs and swap (0), for which no fsck utils exist
+                    fsck = 0 if part.type in ('ntfs', 'swap') else 1 if part.mount_as == '/' else 2
+                    # special mount options for ext* filesystems, defaults for the rest
+                    opts = 'rw,errors=remount-ro' if 'ext' in part.type else 'defaults'
+                    # vfat driver handles fat16 and fat32, swap is swap, everything else is ok as recognized by parted
+                    fs = part.type
+                    if part.type.startswith('fat'):
+                        fs = 'vfat'
+                    if 'swap' in part.type.lower():
+                        fs = 'swap'
+                    # now write this partition entry
+                    fstab.write('# {}\n'.format(part.partition.path))
+                    fstab.write('{uuid}\t{part.mount_as}\t{fs}\t{opts}\t0\t{fsck}\n'.format(**locals()))
 
     def finish_install(self, setup):
         # Steps:


### PR DESCRIPTION
It now much more closely follows the previous behavior. Are there any specific concerns you have with the code?

I also added a few comments to make it more transparent what is going on.

I don't think the slight differences are harmful in any way:

1. Besides fsck-ing rootfs (/), also a separate /home is checked (2), as well as any other partition (there are many `/sbin/fsck.*` available, provided appropriate *{tools,progs,utils} package is installed as it should be). Except ntfs and swap partitions. The former has `/bin/ntfsck` and `ntfsfix` which the authors don't recommend, and the latter needs no checking, I suppose.

2. And the other difference is swap being mounted with `defaults` instead of `sw`. But it works the same.