### PR TITLE
btrfs-subvolume-support

### DIFF
--- a/usr/lib/live-installer/frontend/gtk_interface.py
+++ b/usr/lib/live-installer/frontend/gtk_interface.py
@@ -856,8 +856,27 @@ class InstallerWindow:
                         if partition.format_as is None or partition.format_as == "":
                             ErrorDialog(_("Installation Tool"), _("Please indicate a filesystem to format the root (/) partition with before proceeding."))
                             return
+                    if partition.mount_as == "/@":
+                        if partition.format_as != "btrfs":
+                            ErrorDialog(_("Installation Tool"), _("A root subvolume (/@) requires to format the partition with btrfs."))
+                            return
+                        found_root_partition = True
+                    if partition.mount_as == "/@home":
+                        if partition.format_as == "btrfs":
+                            continue;
+                        if partition.type == "btrfs" and (partition.format_as == None or partition.format_as == ""):
+                            continue;
+                        ErrorDialog(_("Installation Tool"), _("A home subvolume (/@home) requires the use of a btrfs formatted partition."))
+                        return
+
                 if not found_root_partition:
-                    ErrorDialog(_("Installation Tool"), "<b>%s</b>" % _("Please select a root (/) partition."), _("A root partition is needed to install Linux Mint on.\n\n - Mount point: /\n - Recommended size: 30GB\n - Recommended filesystem format: ext4\n "))
+                    ErrorDialog(_("Installation Tool"), "<b>%s</b>" % _("Please select a root (/) partition."), _(
+                        "A root partition is needed to install Linux Mint on.\n\n"
+                        " - Mount point: /\n - Recommended size: 30GB\n"
+                        " - Recommended filesystem format: ext4\n\n"
+                        "Note: The timeshift btrfs snapshots feature requires the use of:\n"
+                        " - subvolume Mount-point /@\n"
+                        " - btrfs as filesystem format\n"))
                     return
 
                 if self.setup.gptonefi:

--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -111,8 +111,52 @@ class InstallerEngine:
                         self.do_mount(partition.path, "/target", fs, None)
                         break
 
+                  if partition.mount_as == "/@" :
+                        if partition.type != "btrfs":
+                            self.error_message(message=_("ERROR: the use of @subvolumes is limited to btrfs"))
+                            return
+                        print "btrfs using /@ subvolume..."
+                        self.update_progress(3, 4, False, False, _("Mounting %(partition)s on %(mountpoint)s") % {'partition':partition.path, 'mountpoint':"/target/"})
+                        # partition.mount_as = "/"
+                        print " ------ Mounting partition %s on %s" % (partition.path, "/target/")
+                        fs = partition.type
+                        self.do_mount(partition.path, "/target", fs, None)
+                        os.system("btrfs subvolume create /target/@")
+                        os.system("btrfs subvolume list -p /target")
+                        print " ------ Umount btrfs to remount subvolume /@"
+                        os.system("umount --force /target")
+                        self.do_mount(partition.path, "/target", fs, "subvol=@")
+                        break
+
+        # handle btrfs /@home subvolume-option after mounting / or /@
+        for partition in setup.partitions:
+            if(partition.mount_as is not None and partition.mount_as != ""):
+                  if partition.mount_as == "/@home":
+                        if partition.type != "btrfs":
+                            self.error_message(message=_("ERROR: the use of @subvolumes is limited to btrfs"))
+                            return
+                        print "btrfs using /@home subvolume..."
+                        self.update_progress(3, 4, False, False, _("Mounting %(partition)s on %(mountpoint)s") % {'partition':partition.path, 'mountpoint':"/target/"})
+                        print " ------ Mounting partition %s on %s" % (partition.path, "/target/home")
+                        fs = partition.type
+                        os.system("mkdir -p /target/home")
+                        self.do_mount(partition.path, "/target/home", fs, None)
+                        # if reusing a btrfs with /@home already being there wont
+                        # currently just keep it; data outside of /@home will still
+                        # be there (just not reachable from the mounted /@home subvolume)
+                        os.system("btrfs subvolume create /target/home/@home")
+                        #os.system("btrfs subvolume list -p /target/home")
+                        print " ------- Umount btrfs to remount subvolume /@home"
+                        os.system("umount --force /target/home")
+                        self.do_mount(partition.path, "/target/home", fs, "subvol=@home")
+                        break
+
         # Mount the other partitions
         for partition in setup.partitions:
+            if(partition.mount_as == "/@home" or partition.mount_as == "/@"):
+                # already mounted as subvolume
+                continue
+
             if(partition.mount_as is not None and partition.mount_as != "" and partition.mount_as != "/" and partition.mount_as != "swap"):
                 print " ------ Mounting %s on %s" % (partition.path, "/target" + partition.mount_as)
                 os.system("mkdir -p /target" + partition.mount_as)
@@ -301,11 +345,25 @@ class InstallerEngine:
 
                     if(partition.mount_as == "/"):
                         fstab_fsck_option = "1"
+                    # section could be removed - just to state/document that fscheck is turned off
+                    # intentionally with /@ (same would be true if btrfs used without a subvol)
+                    # /bin/fsck.btrfs comment states to use fs-check==0 on mount
+                    elif(partition.mount_as == "/@"):
+                        fstab_fsck_option = "0"
                     else:
                         fstab_fsck_option = "0"
 
                     if("ext" in partition.type):
                         fstab_mount_options = "rw,errors=remount-ro"
+                    elif partition.type == "btrfs"  and partition.mount_as == "/@":
+                        fstab_mount_options = "rw,subvol=/@"
+                        # sort of dirty hack - we are done with subvol handling
+                        # mount_as is next used to setup the mount point
+                        partition.mount_as="/"
+                    elif partition.type == "btrfs"  and partition.mount_as == "/@home":
+                        fstab_mount_options = "rw,subvol=/@home"
+                        # sort of dirty hack - see above
+                        partition.mount_as="/home"
                     else:
                         fstab_mount_options = "defaults"
 

--- a/usr/lib/live-installer/partitioning.py
+++ b/usr/lib/live-installer/partitioning.py
@@ -539,7 +539,7 @@ class PartitionDialog(object):
         # Build list of pre-provided mountpoints
         combobox = self.builder.get_object("comboboxentry_mount_point")
         model = Gtk.ListStore(str, str)
-        for i in ["/", "/home", "/boot", "/boot/efi", "/srv", "/tmp", "swap"]:
+        for i in ["/", "/@", "/home", "/@home", "/boot", "/boot/efi", "/srv", "/tmp", "swap"]:
             model.append(["", i])
         combobox.set_model(model)
         combobox.set_entry_text_column(1)


### PR DESCRIPTION
The lmde3 setup does not support  /@ and (optional) /@home subvolumes with btrfs - which is required to enable the usage of timeshift btrfs-snapshots.

- added /@ and /@home  as selectable mountpoints
- modified test on / being available for install
- using /@  requires to (re) format with btrfs - test and error-message
- using /@home requires either (the pre-existing partition) being already formatted as btrfs, or (re) format with btrfs on setup
-