### PR TITLE
Add option "--no-bootloader": this option disable the installation of the EFI packages

### DIFF
--- a/usr/lib/live-installer/frontend/gtk_interface.py
+++ b/usr/lib/live-installer/frontend/gtk_interface.py
@@ -51,7 +51,7 @@ class InstallerWindow:
     # the keyboard layout list
     kbd_preview_generation = -1
 
-    def __init__(self, expert_mode=False):
+    def __init__(self, expert_mode=False, install_bootloader=True):
 
         self.expert_mode = expert_mode
 
@@ -61,6 +61,7 @@ class InstallerWindow:
 
         # build the setup object (where we put all our choices) and the installer
         self.setup = Setup()
+        self.setup.install_bootloader = install_bootloader
         self.installer = InstallerEngine(self.setup)
 
         self.resource_dir = '/usr/share/live-installer/'
@@ -178,8 +179,12 @@ class InstallerWindow:
         grub_box.connect("changed", self.assign_grub_device)
 
         # install Grub by default
-        grub_check.set_active(True)
-        grub_box.set_sensitive(True)
+        if self.setup.install_bootloader:
+            grub_check.set_active(True)
+            grub_box.set_sensitive(True)
+        else:
+            grub_check.set_active(False)
+            grub_box.set_sensitive(False)
 
         # kb models
         cell = Gtk.CellRendererText()

--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -115,7 +115,7 @@ class InstallerEngine:
         if not found_initrd:
             print "WARNING: No initrd found!!"
 
-        if (self.setup.gptonefi):
+        if self.setup.install_bootloader and self.setup.gptonefi:
             print " --> Installing signed boot loader"
             os.system("mkdir -p /target/debs")
             os.system("cp /run/live/medium/pool/main/g/grub2/grub-efi* /target/debs/")
@@ -754,6 +754,7 @@ class Setup(object):
     password1 = None
     password2 = None
     real_name = None
+    install_bootloader = False
     grub_device = None
     disks = []
     automated = True

--- a/usr/lib/live-installer/main.py
+++ b/usr/lib/live-installer/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python -OO
 
+import argparse
 import sys
 import commands
 import gettext
@@ -16,8 +17,9 @@ from gi.repository import Gtk
 # main entry
 if __name__ == "__main__":
 
-	if ("--expert-mode" in sys.argv):
-		win = InstallerWindow(expert_mode=True)
-	else:
-		win = InstallerWindow()
-	Gtk.main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expert-mode", action="store_true", help="Expert mode")
+    parser.add_argument("--no-bootloader", dest="insatll_bootloader", action="store_false", help="Do no install bootloader")
+    args = parser.parse_args()
+    win = InstallerWindow(args.expert_mode, args.insatll_bootloader)
+    Gtk.main()


### PR DESCRIPTION
Hi,

I added the option "--no-botloader" to the live-installer.
This option only disable the installation of the grub-efi-* packages. This is useful for users like me that ran into a system freeze when theose packages are installed by the installer.