### PR TITLE
Don't install EFI packages if "Install GRUB" is not checked

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -115,7 +115,7 @@ class InstallerEngine:
         if not found_initrd:
             print "WARNING: No initrd found!!"
 
-        if (self.setup.gptonefi):
+        if self.setup.grub_device and self.setup.gptonefi:
             print " --> Installing signed boot loader"
             os.system("mkdir -p /target/debs")
             os.system("cp /run/live/medium/pool/main/g/grub2/grub-efi* /target/debs/")


### PR DESCRIPTION
Disabling GRUB installlation does not disable EFI packages installation. On some systems, the installation freeze during EFI packages installation. So, if GRUB installation is disable, no bootloader package should be installed.
This is what this fix does: No GRUB -> No EFI.

This is a simplier version of #107.