### PR TITLE
OEM: Use a different UID for Temporary OEM User

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -38,14 +38,17 @@ class InstallerEngine:
 
     def setup_user(self):
         print(" --> Adding new user")
+        options = []
         if self.setup.ecryptfs:
             # ecryptfs looks for the /sys mount point in /etc/mtab.. which doesn't exist during the installation.
             # it defaults to /sys anyway, so we just need to create an empty /etc/mtab file at this stage.
             self.do_run_in_chroot('touch /etc/mtab')
             self.do_run_in_chroot('modprobe ecryptfs')
-            self.do_run_in_chroot('adduser --disabled-password --encrypt-home --gecos "{real_name}" {username}'.format(real_name=self.setup.real_name.replace('"', r'\"'), username=self.setup.username))
-        else:
-            self.do_run_in_chroot('adduser --disabled-password --gecos "{real_name}" {username}'.format(real_name=self.setup.real_name.replace('"', r'\"'), username=self.setup.username))
+            options += ["--encrypt-home"]
+        if self.setup.oem_mode:
+            # Use a different UID for internal oem user, so that the final user can use FIRST_UID (1000).
+            options += ["--firstuid", "2000"]
+        self.do_run_in_chroot('adduser --disabled-password {options} --gecos "{real_name}" {username}'.format(options=" ".join(options), real_name=self.setup.real_name.replace('"', r'\"'), username=self.setup.username))
         for group in 'adm audio bluetooth cdrom dialout dip fax floppy fuse lpadmin netdev plugdev powerdev sambashare scanner sudo tape users vboxusers video'.split():
             self.do_run_in_chroot("adduser {user} {group}".format(user=self.setup.username, group=group))
 


### PR DESCRIPTION
The installer creates internal `oem` user with UID 1000, so that the actual user created at later setup gets UID 1001.

This might cause some issues, especially when using external drives due to file owner permissions,
because in most cases the user UID is 1000 (as long as you don't share your computer with others).