### PR TITLE
btrfs: Improve fstab mount options during a btrfs install

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -592,9 +592,9 @@ class InstallerEngine:
                         if "ext" in fs:
                             fstab_mount_options = "rw,errors=remount-ro"
                         elif fs == "btrfs" and partition.mount_as == "/":
-                            fstab_mount_options = "defaults,subvol=@"
+                            fstab_mount_options = "subvol=@,defaults,noatime,compress=zstd:1,discard=async"
                         elif fs == "btrfs" and partition.mount_as == "/home":
-                            fstab_mount_options = "defaults,subvol=@home"
+                            fstab_mount_options = "subvol=@home,defaults,noatime,compress=zstd:1,discard=async"
                         else:
                             fstab_mount_options = "defaults"
 
@@ -606,7 +606,7 @@ class InstallerEngine:
 
                         if fs == "btrfs" and partition.mount_as == "/" and not self.setup_has_dedicated_home():
                             # Special case, if / is btrfs and there is no dedicated /home, add the @home subvolume to /
-                            fstab.write("%s\t%s\t%s\t%s\t%s\t%s\n" % (partition_uuid, "/home", "btrfs", "defaults,subvol=@home", "0", "0"))
+                            fstab.write("%s\t%s\t%s\t%s\t%s\t%s\n" % (partition_uuid, "/home", "btrfs", "subvol=@home,defaults,noatime,compress=zstd:1,discard=async", "0", "0"))
         fstab.close()
 
     def write_mtab(self, fstab="/target/etc/fstab", mtab="/target/etc/mtab"):

--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -592,9 +592,9 @@ class InstallerEngine:
                         if "ext" in fs:
                             fstab_mount_options = "rw,errors=remount-ro"
                         elif fs == "btrfs" and partition.mount_as == "/":
-                            fstab_mount_options = "subvol=@,defaults,noatime,compress=zstd:1,discard=async"
+                            fstab_mount_options = "subvol=@,defaults,noatime,compress=zstd:1"
                         elif fs == "btrfs" and partition.mount_as == "/home":
-                            fstab_mount_options = "subvol=@home,defaults,noatime,compress=zstd:1,discard=async"
+                            fstab_mount_options = "subvol=@home,defaults,noatime,compress=zstd:1"
                         else:
                             fstab_mount_options = "defaults"
 
@@ -606,7 +606,7 @@ class InstallerEngine:
 
                         if fs == "btrfs" and partition.mount_as == "/" and not self.setup_has_dedicated_home():
                             # Special case, if / is btrfs and there is no dedicated /home, add the @home subvolume to /
-                            fstab.write("%s\t%s\t%s\t%s\t%s\t%s\n" % (partition_uuid, "/home", "btrfs", "subvol=@home,defaults,noatime,compress=zstd:1,discard=async", "0", "0"))
+                            fstab.write("%s\t%s\t%s\t%s\t%s\t%s\n" % (partition_uuid, "/home", "btrfs", "subvol=@home,defaults,noatime,compress=zstd:1", "0", "0"))
         fstab.close()
 
     def write_mtab(self, fstab="/target/etc/fstab", mtab="/target/etc/mtab"):


### PR DESCRIPTION
I've improved the btrfs install to use compression by default (which reduces writes and uses less storage) and some other options that should be better for modern SSDs.

Used as a reference the fstab mounts in distros such as **Fedora** and **CachyOS** which use similar mount options for btrfs, and this reference on BTRFS mount options I found: https://wiki.tnonline.net/w/Btrfs/Mount_Options 

Tested the installation with both a single root partition on btrfs and split root and home partion when both on btrfs and it worked well in both cases.