### PR TITLE
keyboard: Don't crash if setxkbmap query fails or returns unexpected output

### DIFF
--- a/usr/lib/live-installer/main.py
+++ b/usr/lib/live-installer/main.py
@@ -747,9 +747,26 @@ class InstallerWindow:
 
     def build_kb_lists(self):
         ''' Do some xml kung-fu and load the keyboard stuffs '''
-        # Determine the layouts in use
-        (keyboard_geom,
-         self.setup.keyboard_layout) = subprocess.getoutput("setxkbmap -query | awk '/^(model|layout)/{print $2}'").split()
+        # Best-effort detection of the live session's current keyboard model
+        # and layout. If setxkbmap is unavailable or returns unexpected output
+        # (e.g. a shell error, or an environment where the X-protocol query
+        # fails), leave these as None so the dropdowns simply aren't
+        # pre-selected -- the downstream "except NameError" blocks already
+        # handle that gracefully. Crashing the installer here is much worse
+        # than asking the user to pick from the list.
+        keyboard_geom = None
+        self.setup.keyboard_layout = None
+        try:
+            for line in subprocess.getoutput("setxkbmap -query").splitlines():
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                if parts[0] == "model:":
+                    keyboard_geom = parts[1]
+                elif parts[0] == "layout:":
+                    self.setup.keyboard_layout = parts[1]
+        except Exception:
+            pass
         # Build the models
         from collections import defaultdict
         def _ListStore_factory():


### PR DESCRIPTION
## Summary
Fixes #176 — `ValueError: too many values to unpack (expected 2)` from `build_kb_lists()` when launching the installer on a live LMDE 7 session.

## Root cause
`usr/lib/live-installer/main.py:752` parsed the live session's `setxkbmap -query` output by piping through `awk` and tuple-unpacking the result of `.split()` into exactly two names. `.split()` collapses *all* whitespace including newlines, so the unpack only succeeds when there are precisely two whitespace-separated tokens in the entire output. Anything else raises `ValueError` and aborts the installer before the keyboard page can render.

The most likely real-world trigger — and the one consistent with the traceback in #176 — is `setxkbmap` failing (binary missing on the live image, or an environment where the X-protocol query can't run). When that happens, `subprocess.getoutput` returns shell error text like `sh: 1: setxkbmap: not found` — five tokens, instant crash.

## Fix
Parse `setxkbmap -query` line-by-line, picking off `model:` and `layout:` if present. If the query fails or the lines aren't there, leave the locals at `None`. The downstream pre-selection logic at `main.py:794-802` already wraps the lookups in `except NameError`, so an unset/`None` value just means "no pre-selection" — the user picks from the list manually, which is far better than a hard crash.

Behavior on the happy path is unchanged: normal `setxkbmap -query` output produces the same `(model, layout)` pair as before, including the comma-separated form for multi-layout setups.

## Test plan
- [x] Python syntax check on the patched file (`python3 -m py_compile`).
- [x] Unit-tested the new parser against: normal output, multi-layout (`us,de`), missing `setxkbmap` (shell error), empty output, partial output (only `model:` / only `layout:`), and lines with junk preceding the real ones. Happy path identical to old behavior; all failure modes return `(None, None)` or `(None, value)` instead of crashing.
- [ ] End-to-end run on a live LMDE 7 ISO on the affected hardware (Dell OptiPlex 755 from #176) — left for reviewers with that environment, since the original report could not reach the installer at all without this fix.