### PR TITLE
partitioning: settle udev and abort on mkfs failure in full_disk_format

### DIFF
--- a/usr/lib/live-installer/partitioning.py
+++ b/usr/lib/live-installer/partitioning.py
@@ -470,6 +470,10 @@ def full_disk_format(device, create_boot=False, create_swap=True):
             partition_path = "%s%s%d" % (device.path, partition_prefix, partition_number)
             num_tries = 0
             while True:
+                # Each parted invocation triggers a partition-table rescan;
+                # udev briefly removes and recreates the device nodes. Wait
+                # for it to finish or mkfs can race a vanishing node.
+                os.system("udevadm settle 2>/dev/null")
                 if os.path.exists(partition_path):
                     break
                 if num_tries < 5:
@@ -481,7 +485,11 @@ def full_disk_format(device, create_boot=False, create_swap=True):
                     raise Exception(_("The partition %s could not be created. The installation will stop. Restart the computer and try again.") % partition_path)
             mkfs = mkfs.format(partition_path)
             print(mkfs)
-            os.system(mkfs)
+            if os.system(mkfs) != 0:
+                # A failed format must stop the installation here: if this is
+                # tolerated, mounting fails silently and the file copy lands
+                # in the live session's tmpfs until it fills up.
+                raise Exception(_("The partition %s could not be formatted. The installation will stop. Restart the computer and try again.") % partition_path)
             start_mb += size_mb + 1
     if installer.setup.gptonefi:
         run_parted('set 1 boot on')


### PR DESCRIPTION
`full_disk_format()` formats each new partition without waiting for udev to settle after parted's table rescan and without checking the `mkfs` return code, so `mkfs` can race a briefly-removed partition node; the silent failure later surfaces as a disk-full error when the file copy lands in the live tmpfs.

Fix:
- Run `udevadm settle` before the node-existence check after each parted call. parted's rescan briefly removes and recreates the nodes; settling closes that window. No-op if `udevadm` is absent (stderr suppressed; falls through to the existing `os.path.exists` retry loop).
- Raise if `os.system(mkfs)` returns non-zero — a partition that failed to format must stop the install. This mirrors the existing `mklabel` return-code check a few lines up.

Testing (LMDE 7, QEMU/KVM):
- Plain and encrypted automated installs complete and boot — the settle adds no regression.
- With `mkfs.ext4` forced to fail, the install now aborts in `full_disk_format()` instead of silently continuing into the live tmpfs.

Split out of #180 so it can land independently.

Fixes #181
