### PR TITLE
installer: Feed LUKS passphrase to cryptsetup on stdin

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -5,7 +5,6 @@ import time
 import gettext
 import parted
 import partitioning
-import shlex
 from functools import cmp_to_key
 
 gettext.install("live-installer", "/usr/share/locale")
@@ -442,12 +441,18 @@ class InstallerEngine:
         disk_device = parted.getDevice(self.setup.disk)
         partitioning.full_disk_format(disk_device, create_boot=(self.auto_boot_partition is not None), create_swap=(self.auto_swap_partition is not None))
 
-        # Encrypt root partition
+        # Encrypt root partition. The passphrase is fed to cryptsetup on
+        # stdin (--key-file -), never as a command argument: this keeps it
+        # out of the process table (ps) and out of any logs. Previously the
+        # engine built 'echo -n <pass> | cryptsetup ...', so the passphrase
+        # was briefly visible to any local user running ps.
         if self.setup.luks:
             print(" --> Encrypting root partition %s" % self.auto_root_partition)
-            os.system("echo -n %s | cryptsetup luksFormat -c aes-xts-plain64 -h sha256 -s 512 %s" % (shlex.quote(self.setup.passphrase1), self.auto_root_partition))
+            subprocess.run("cryptsetup luksFormat -c aes-xts-plain64 -h sha256 -s 512 --key-file - %s" % self.auto_root_partition,
+                           shell=True, input=self.setup.passphrase1.encode("utf-8"))
             print(" --> Opening root partition %s" % self.auto_root_partition)
-            os.system("echo -n %s | cryptsetup luksOpen %s lvmmint" % (shlex.quote(self.setup.passphrase1), self.auto_root_partition))
+            subprocess.run("cryptsetup luksOpen --key-file - %s lvmmint" % self.auto_root_partition,
+                           shell=True, input=self.setup.passphrase1.encode("utf-8"))
             self.auto_root_partition = "/dev/mapper/lvmmint"
 
         # Setup LVM


### PR DESCRIPTION
During an encrypted install `create_partitions()` ran `os.system("echo -n <pass> | cryptsetup luksFormat/luksOpen ...")`. `os.system` runs `/bin/sh -c "<string>"`, so the passphrase sat in the shell's argv and was readable from the process table (`ps`) by any local user during the encrypt window.

Fix: pass the passphrase to cryptsetup on stdin via `--key-file -`, using `subprocess.run(..., input=passphrase.encode("utf-8"))`, so it is never a command argument. `luksFormat` and `luksOpen` change identically, so the derived key is unchanged (same bytes, no trailing newline, read until EOF as with the old `echo -n`). The now-unused `shlex` import is dropped; the change is confined to the existing `if self.setup.luks:` block.

Testing (LMDE 7, QEMU/KVM): instrumented `ps` across `luksFormat`/`luksOpen` during an encrypted install. The old `echo | cryptsetup` form shows the passphrase in the process table; the stdin form does not (11k+ samples). The install completes and the volume unlocks with the chosen passphrase.

Split out of #180 so it can land independently.

Fixes #182
