### PR TITLE
installer: Rebuild initramfs for LUKS installs so crypttab reaches the initramfs

### DIFF
--- a/usr/lib/live-installer/installer.py
+++ b/usr/lib/live-installer/installer.py
@@ -717,6 +717,24 @@ class InstallerEngine:
         # recreate initramfs (needed in case of skip_mount also, to include things like mdadm/dm-crypt/etc in case its needed to boot a custom install)
         print(" --> Configuring Initramfs")
         self.do_run_in_chroot("/usr/sbin/update-initramfs -t -u -k all")
+        if self.setup.luks:
+            # The target is copied from the live squashfs, so it carries
+            # live-boot's diverted update-initramfs: a wrapper that no-ops
+            # unless the live medium is mounted at /run/live/medium inside
+            # the chroot. /run is bind-mounted non-recursively, so that
+            # submount is absent and the call above is silently skipped --
+            # the crypttab never reaches the initramfs and the encrypted
+            # root can't be unlocked at boot (the system drops to an
+            # initramfs shell). Plain and LVM installs boot the stock
+            # initramfs and are unaffected; only LUKS needs the rebuild.
+            #
+            # Remove live-boot's initramfs hook (it references a live-only
+            # path, /usr/lib/live/boot, and fails on the installed system)
+            # and run the real, un-diverted update-initramfs so the crypttab
+            # is baked in.
+            self.do_run_in_chroot("rm -f /usr/share/initramfs-tools/hooks/live")
+            real_update_initramfs = subprocess.getoutput("chroot /target/ /bin/sh -c 'dpkg-divert --truename /usr/sbin/update-initramfs'").strip() or "/usr/sbin/update-initramfs"
+            self.do_run_in_chroot("%s -u -k all" % real_update_initramfs)
         self.do_run_in_chroot(self.grub_adjustment_script)
         kernelversion= subprocess.getoutput("uname -r")
         self.do_run_in_chroot("/usr/bin/sha1sum /boot/initrd.img-%s > /var/lib/initramfs-tools/%s" % (kernelversion,kernelversion))


### PR DESCRIPTION
A UEFI encrypted (LVM-on-LUKS) install completes but cannot boot: it drops to an initramfs shell (`ALERT! /dev/mapper/lvmmint-root does not exist`). The target inherits live-boot's diverted `update-initramfs`, which no-ops unless the live medium is mounted at `/run/live/medium` inside the chroot. `/run` is bind-mounted non-recursively, so that submount is absent and `finish_installation()`'s `update-initramfs` call is silently skipped, leaving the crypttab out of the initramfs.

Fix, gated on `self.setup.luks`: remove live-boot's initramfs hook (`/usr/share/initramfs-tools/hooks/live`, which references the live-only `/usr/lib/live/boot` and fails on the installed system), resolve the real un-diverted `update-initramfs` via `dpkg-divert --truename`, and run it in the chroot so the cryptsetup hook bakes in `/conf/conf.d/cryptroot`.

Scope/regression: the guard means plain and LVM-without-encryption installs are untouched. On a target with no live-boot diversion, `dpkg-divert --truename` returns the plain `/usr/sbin/update-initramfs` and the `rm -f` of the absent hook is a no-op, so it just runs `update-initramfs` one extra (harmless) time. On BIOS, where this layout already boots, the rebuild is a harmless no-op improvement. The manual-partition (`skip_mount`) dm-crypt path is not covered.

Testing (LMDE 7, OVMF/QEMU): a UEFI LVM-on-LUKS install on `master` drops to an initramfs shell at boot; with this change it prompts for the passphrase, unlocks, and boots. BIOS installs of the same layout boot in both cases.

Split out of #180 so it can be reviewed and land independently.

Fixes #183
